### PR TITLE
Create a publish to npm workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,36 @@
+name: Publish to npm
+
+on:
+  push:
+    tags:
+      - 'v*'  # Triggers on version tags like v1.0.0, v0.9.6, etc.
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    
+    permissions:
+      contents: read
+      id-token: write  # Required for OIDC
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          registry-url: 'https://registry.npmjs.org'
+      
+      - name: Install dependencies
+        run: npm ci
+      
+      - name: Build
+        run: npm run build
+      
+      - name: Test
+        run: npm test
+      
+      - name: Publish to npm
+        run: npm publish

--- a/package.json
+++ b/package.json
@@ -40,8 +40,11 @@
   "homepage": "https://github.com/softbrix/dibba-tree#readme",
   "devDependencies": {
     "@types/mocha": "^10.0.6",
-    "@types/node": "^20.10.0",
+    "@types/node": "^22.0.0",
     "mocha": "^10.2.0",
     "typescript": "^5.3.3"
+  },
+  "engines": {
+    "node": ">=22.0.0"
   }
 }


### PR DESCRIPTION
This pull request automates the npm publishing workflow and updates the project's Node.js requirements. The main changes are the addition of a GitHub Actions workflow for publishing on tag pushes and the update of Node.js version requirements in `package.json`.

**Continuous Integration & Deployment:**

* Added a new GitHub Actions workflow (`.github/workflows/publish.yml`) to automate publishing to npm when a new version tag is pushed. This workflow checks out the code, sets up Node.js 22, installs dependencies, builds, tests, and publishes the package.

**Node.js Version Updates:**

* Updated the `@types/node` development dependency to version 22 and specified a minimum Node.js engine requirement of 22.0.0 in `package.json`.